### PR TITLE
Changes for NetSuite tests

### DIFF
--- a/common.py
+++ b/common.py
@@ -214,28 +214,3 @@ def find_and_switch_to_frame(driver_, frame_name):
         if iframe.get_property("name") == frame_name:
             switch_to_frame(driver_, iframe)
             return
-def check_window_is_open(driver_, window_name):
-    for handle in driver_.window_handles:
-        title = driver_.title
-        if title.lower().__contains__(window_name):
-            return True
-        else:
-            driver_.switch_to.window(handle)
-    return False
-
-def find_and_switch_to_frame(driver_, frame_name):
-    iframes = driver_.find_elements(By.XPATH, "//iframe")
-    
-    if len(iframes) == 0:
-        driver_.refresh()
-        wait_page_to_be_loaded(driver_)
-        iframes = driver_.find_elements(By.XPATH, "//iframe")
-
-        if len(iframes) == 0:
-            raise NoSuchElementException
-
-    for index, iframe in enumerate(iframes):
-        # print(iframe)
-        if iframe.get_property("name") == frame_name:
-            switch_to_frame(driver_, iframe)
-            return

--- a/configuration/lab/qa01.yml
+++ b/configuration/lab/qa01.yml
@@ -1,6 +1,8 @@
 configuration:
     login_url: https://qalogin01.five9lab.com/
+    #TODO: Check correct link for adapters on Lab01
     adapter_login_url: https://qaapp11d.five9lab.com/clients/integrations/adt.main.html
+    adapter_ns_login_url: qaapp11d.five9lab.com
     chat_console_url: https://qaapp01.five9lab.com/consoles/ChatConsole/ChatDemo.html?tenant=iferreira_lab&profiles=iferreira_chat
     email_console_url: https://qaapp01.five9lab.com/five9_clients/consoles_latest/EmailConsole/EmailDemo.html?tenant=iferreira_lab&profiles=iferreira_chat
     connector_url: https://www.google.com/
@@ -21,6 +23,11 @@ credentials:
         outbound_camp: <outbound>
 
 sf_credentials:
+    agent_0:
+        user: <user>
+        pass: <pass>
+
+ns_credentials:
     agent_0:
         user: <user>
         pass: <pass>

--- a/configuration/lab/qa01.yml
+++ b/configuration/lab/qa01.yml
@@ -1,8 +1,7 @@
 configuration:
     login_url: https://qalogin01.five9lab.com/
-    #TODO: Check correct link for adapters on Lab01
-    adapter_login_url: https://qaapp11d.five9lab.com/clients/integrations/adt.main.html
-    adapter_ns_login_url: qaapp11d.five9lab.com
+    adapter_login_url: https://qaapp01d.five9lab.com/clients/integrations/adt.main.html
+    adapter_ns_login_url: qaapp01d.five9lab.com
     chat_console_url: https://qaapp01.five9lab.com/consoles/ChatConsole/ChatDemo.html?tenant=iferreira_lab&profiles=iferreira_chat
     email_console_url: https://qaapp01.five9lab.com/five9_clients/consoles_latest/EmailConsole/EmailDemo.html?tenant=iferreira_lab&profiles=iferreira_chat
     connector_url: https://www.google.com/

--- a/configuration/lab/qa02.yml
+++ b/configuration/lab/qa02.yml
@@ -2,6 +2,7 @@ configuration:
   login_url: https://qalogin11.five9lab.com/
   direct_login_url: https://qaapp11.five9lab.com/?role=Agent
   adapter_login_url: https://qaapp11d.five9lab.com/clients/integrations/adt.main.html
+  adapter_ns_login_url: qaapp11d.five9lab.com
   chat_console_url: https://qaapp11.five9lab.com/five9_clients/consoles_latest/ChatConsole/ChatDemo.html?tenant=mci_qa02_autocert&profiles=<chat_camp>
   email_console_url: https://qaapp11.five9lab.com/consoles/EmailConsole/EmailDemo.html?tenant=mci_qa02_autocert&profiles=<chat_camp>
   connector_url: https://www.google.com/
@@ -23,7 +24,11 @@ credentials:
     outbound_camp: cert_out
 
 sf_credentials:
-    agent_0:
+  agent_0:
         user: <user>
         pass: <pass>
-    
+
+ns_credentials:
+  agent_0:
+      user: <user>
+      pass: <pass>

--- a/configuration/local.yml
+++ b/configuration/local.yml
@@ -10,7 +10,7 @@ configuration:
     test_name: <any_name>
 
 chrome_flags:
-    third_party_cookie_phaseout: --test-third-party-cookie-phaseout
+    # third_party_cookie_phaseout: --test-third-party-cookie-phaseout
     use-fake-ui-for-media-stream: --use-fake-ui-for-media-stream
 
 chrome_experimental:
@@ -19,3 +19,4 @@ chrome_experimental:
 chrome_extensions:
     softphone: 'softphone.crx'
     adt_plus: 'adt_plus.crx'
+    netsuite: 'netsuite.crx'

--- a/configuration/local.yml
+++ b/configuration/local.yml
@@ -10,7 +10,7 @@ configuration:
     test_name: <any_name>
 
 chrome_flags:
-    # third_party_cookie_phaseout: --test-third-party-cookie-phaseout
+    third_party_cookie_phaseout: --test-third-party-cookie-phaseout
     use-fake-ui-for-media-stream: --use-fake-ui-for-media-stream
 
 chrome_experimental:

--- a/page_objects/adapters/adapter_login_page.py
+++ b/page_objects/adapters/adapter_login_page.py
@@ -4,8 +4,7 @@ from selenium.webdriver.common.by import By
 class AdapterLoginPage(object):
     def __init__(self, driver=None):
         self.driver = driver
-        self.adt_url = "https://qaapp01d.five9lab.com/clients/integrations/adt.main.html"
-        self.ns_url = "qaapp11d.five9lab.com"
+        self.url = "https://qaapp01d.five9lab.com/clients/integrations/adt.main.html"
         self.adapter_user_input = "//input[@id='username']"
         self.adapter_pass_input = "//input[@id='password']"
         self.adapter_login_button = "//button[contains(@id,'login_btn')]"

--- a/page_objects/adapters/adapter_login_page.py
+++ b/page_objects/adapters/adapter_login_page.py
@@ -4,14 +4,15 @@ from selenium.webdriver.common.by import By
 class AdapterLoginPage(object):
     def __init__(self, driver=None):
         self.driver = driver
-        self.url = "https://qaapp01d.five9lab.com/clients/integrations/adt.main.html"
+        self.adt_url = "https://qaapp01d.five9lab.com/clients/integrations/adt.main.html"
+        self.ns_url = "qaapp11d.five9lab.com"
         self.adapter_user_input = "//input[@id='username']"
         self.adapter_pass_input = "//input[@id='password']"
         self.adapter_login_button = "//button[contains(@id,'login_btn')]"
         self.force_login_button = "//button[@id='force-login']"
 
-    def open_page(self):
-        self.driver.get(self.url)
+    def open_page(self, url="https://qaapp01d.five9lab.com/clients/integrations/adt.main.html"):
+        self.driver.get(url)
 
     def get_adapter_user_input(self):
         return self.driver.find_element(By.XPATH, self.adapter_user_input)

--- a/page_objects/adapters/adapter_login_page.py
+++ b/page_objects/adapters/adapter_login_page.py
@@ -10,8 +10,8 @@ class AdapterLoginPage(object):
         self.adapter_login_button = "//button[contains(@id,'login_btn')]"
         self.force_login_button = "//button[@id='force-login']"
 
-    def open_page(self, url="https://qaapp01d.five9lab.com/clients/integrations/adt.main.html"):
-        self.driver.get(url)
+    def open_page(self):
+        self.driver.get(self.url)
 
     def get_adapter_user_input(self):
         return self.driver.find_element(By.XPATH, self.adapter_user_input)

--- a/page_objects/sf_login_page.py
+++ b/page_objects/sf_login_page.py
@@ -3,17 +3,24 @@ from selenium.webdriver.common.by import By
 class SFLoginPage(object):
     def __init__(self, driver=None):
         self.driver = driver
-        self.user_input = "//input[@id='username']"
+        self.user_input = "//input[@id='username'] | //input[@id='email']"
         self.pass_input = "//input[@id='password']"
-        self.login_button = "//input[@id='Login']"
-        self.logo_img = "//img[@id='phHeaderLogoImage']"
-        self.url = 'https://login.salesforce.com/'
+        self.login_button = "//input[@id='Login'] | //button[@id='submitButton']"
+        self.logo_img = "//img[@id='phHeaderLogoImage'] | //div[@id='uif35']"
+        self.sf_url = "https://login.salesforce.com/"
+        self.ns_url = "https://system.netsuite.com/pages/customerlogin.jsp?country=US"
+        self.ns_additional_auth_title = "//div[@class='roleswitch-title']/h1"
+        self.ns_additional_pass = "//input[@name='answer']"
+        self.ns_additional_submit_btn = "//input[@name='submitter']"
 
-    def open_page(self):
-        self.driver.get(self.url)
+    def open_page(self, url="https://login.salesforce.com/"):
+        self.driver.get(url)
 
-    def get_url(self):
-        return self.url
+    def get_salesforce_url(self):
+        return self.sf_url
+    
+    def get_netsuite_url(self):
+        return self.ns_url
 
     def get_user_input(self):
         return self.driver.find_element(By.XPATH, self.user_input)
@@ -26,3 +33,12 @@ class SFLoginPage(object):
     
     def get_logo_img(self):
         return self.driver.find_element(By.XPATH, self.logo_img)
+    
+    def get_ns_additional_auth_title(self):
+        return self.driver.find_element(By.XPATH, self.ns_additional_auth_title)
+    
+    def get_ns_additional_pass(self):
+        return self.driver.find_element(By.XPATH, self.ns_additional_pass)
+    
+    def get_ns_additional_submit_btn(self):
+        return self.driver.find_element(By.XPATH, self.ns_additional_submit_btn)

--- a/page_objects/sf_login_page.py
+++ b/page_objects/sf_login_page.py
@@ -7,14 +7,14 @@ class SFLoginPage(object):
         self.pass_input = "//input[@id='password']"
         self.login_button = "//input[@id='Login'] | //button[@id='submitButton']"
         self.logo_img = "//img[@id='phHeaderLogoImage'] | //div[@id='uif35']"
-        self.sf_url = "https://login.salesforce.com/"
+        self.url = "https://login.salesforce.com/"
         self.ns_url = "https://system.netsuite.com/pages/customerlogin.jsp?country=US"
         self.ns_additional_auth_title = "//div[@class='roleswitch-title']/h1"
         self.ns_additional_pass = "//input[@name='answer']"
         self.ns_additional_submit_btn = "//input[@name='submitter']"
 
-    def open_page(self, url="https://login.salesforce.com/"):
-        self.driver.get(url)
+    def open_page(self):
+        self.driver.get(self.url)
 
     def get_salesforce_url(self):
         return self.sf_url

--- a/step_definitions/adapters/adapter_login_steps.py
+++ b/step_definitions/adapters/adapter_login_steps.py
@@ -1,8 +1,11 @@
 from pytest_bdd import when, then
 from selenium.webdriver import Keys
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.webdriver.common.by import By
 
 import common
+import pyautogui
+import driver
 from page_objects.adapters.adapter_login_page import AdapterLoginPage
 from step_definitions import common_steps
 from step_definitions.adapters import adapter_steps
@@ -64,3 +67,21 @@ def adapter_logout():
                 agent_info['driver'] = None
                 agent_info['login_type'] = None
                 common_steps.AGENT_CREDENTIALS[agent_] = agent_info
+
+@when("I launch the adapter")
+def launch_adapter():
+    # open the adapter window
+    for _driver in driver.DRIVERS:
+        driver_ = driver.DRIVERS.get(_driver).get('instance')
+        driver_.switch_to.window(driver_.current_window_handle)
+        for attempt in range(10):
+            common.wait_element_to_be_clickable(driver_, "//body")
+            common.click_element(driver_, driver_.find_element(By.TAG_NAME, "body"))
+            pyautogui.hotkey(
+                PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[1], 'i')
+            common.system_wait(2)
+            if len(driver_.window_handles) > 1:
+                common.switch_tabs(driver_=driver_, tab_id=driver_.window_handles[1])
+                if driver_.title != 'Adapter':
+                    common.wait_page_element_load(driver_, "//*[@id='username']", 60)
+                    break

--- a/step_definitions/adapters/adapter_login_steps.py
+++ b/step_definitions/adapters/adapter_login_steps.py
@@ -17,6 +17,7 @@ PLATFORM_HOTKEYS = {
     'linux': [Keys.CONTROL, 'control']
 }
 EXTENSION_NAME = "Five9 Agent Desktop Toolkit"
+NS_EXTENSION_NAME = "Five9Lab Plus Adapter for NetSuite"
 
 def check_force_login(agent):
     try:

--- a/step_definitions/common_steps.py
+++ b/step_definitions/common_steps.py
@@ -2,9 +2,11 @@ import common
 import driver
 from selenium.common import NoSuchElementException
 from selenium.webdriver.common.by import By
+from selenium.webdriver import ActionChains
 from page_objects.common_page import CommonPage
 from pytest_bdd import given, when, parsers
 from step_definitions import login_steps
+from selenium.webdriver import Keys
 
 STARTED_PAGES = []
 COMMON_PAGE = CommonPage()
@@ -16,6 +18,11 @@ MODAL_TYPES = {
     'manual': '(Manual)'
 }
 AGENT_CREDENTIALS = {}
+PLATFORM_HOTKEYS = {
+    'windows': [Keys.CONTROL, 'ctrl'],
+    'mac': [Keys.COMMAND, 'command'],
+    'linux': [Keys.CONTROL, 'control']
+}
 TEARDOWN = False
 
 
@@ -203,6 +210,81 @@ def select_modal_next_button():
                 pass
     common.system_wait(1)
     assert button_clicked, "COULD NOT FIND OR CLICK IN NEXT BUTTON"
+
+
+def set_adapter_shortcut(driver_, extension_text, return_id=False):
+    driver_.get("chrome://extensions")
+    extension_manager_element_shadow = driver_.find_element(By.XPATH, "//extensions-manager")
+    extension_items_list_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
+                                                                                            "#items-list")
+    extensions = extension_items_list_shadow.shadow_root.find_elements(By.CSS_SELECTOR, "extensions-item")
+    selected_extension = None
+    for extension in extensions:
+        extension_name = extension.shadow_root.find_element(By.CSS_SELECTOR, "#name").text.strip()
+        if extension_name == extension_text:
+            selected_extension = extension
+            break
+    if not selected_extension:
+        raise Exception(f"extension {extension_text} not found")
+
+    # open extension options
+    selected_extension.shadow_root.find_element(By.CSS_SELECTOR, "#detailsButton").click()
+    common.wait_page_to_be(driver_, "?id=")
+    if return_id:
+        return driver_.current_url.split("?id=")[1].strip()
+
+    left_panel_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR, "extensions-sidebar")
+    keyboard_shortcuts = left_panel_shadow.shadow_root.find_element(By.CSS_SELECTOR, "a#sectionsShortcuts")
+    keyboard_shortcuts.click()
+
+    keyboard_shortcuts_content_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
+                                                                                                  "extensions-keyboard-shortcuts")
+    extension_cards = keyboard_shortcuts_content_shadow.shadow_root.find_elements(By.CSS_SELECTOR, ".shortcut-card")
+    selected_extension_card = None
+    for extension_card in extension_cards:
+        if extension_text in extension_card.text:
+            selected_extension_card = extension_card
+            break
+    if not selected_extension_card:
+        raise Exception(f"card for {extension_text} extension not found")
+
+    action = ActionChains(driver_)
+    edit_shortcut_shadow = selected_extension_card.find_element(By.CSS_SELECTOR, "extensions-shortcut-input")
+    edit_shortcut_button = edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-icon-button#edit")
+    edit_shortcut_button.click()
+    edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-input").shadow_root.find_element(By.CSS_SELECTOR, "#input").click()
+    action.key_down(PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
+        .send_keys('i')\
+        .key_up(PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
+        .perform()
+    
+def set_adapter_url(driver_, extension_id, steps_obj, adpt_url='adapter_login_url'):
+    lab_config = f"configuration/lab/{common.get_config_file_section('config.yml', 'configuration').get('lab')}.yml"
+    adapter_url = common.get_config_file_section(lab_config, 'configuration').get(adpt_url)
+    if not adapter_url:
+        adapter_url = steps_obj.url
+    steps_obj.url = adapter_url
+    driver_.get(f"chrome-extension://{extension_id}/options.html")
+    common.system_wait(2)
+
+    # set extension url
+    if adpt_url != 'adapter_login_url':
+        driver_.find_element(By.XPATH, "//select[@id='domain-select']/option[@value='Custom']").click()
+    input_url = driver_.find_element(By.XPATH, "//input[@id='url'] | //input[@id='custom-host']")
+    input_url.clear()
+    input_url.click()
+    input_url.send_keys(adapter_url)
+    try:
+        assert input_url.get_attribute('value') == adapter_url
+    except AssertionError:
+        input_url.clear()
+        input_url.send_keys(adapter_url)
+        assert input_url.get_attribute('value') == adapter_url, "COULD NOT SET THE CORRECT URL"
+    driver_.find_element(By.XPATH, "//button[@id='save']").click()
+    common.wait_element_attribute_contains(driver_, "//mark[@id='status']", 'innerText', "Options Saved")
+    tab_info = {'title': driver_.title,
+                'browser_number': int(common.get_driver_by_instance(driver_))}
+    common.BROWSER_TABS[driver_.current_window_handle] = tab_info
 
 
 @when("I check the new browser tab opened")

--- a/step_definitions/sf_login_steps.py
+++ b/step_definitions/sf_login_steps.py
@@ -18,6 +18,8 @@ def check_additional_authentication():
 
 @given("I am in SF login page")
 @when("I am in SF login page")
+@given("I am in NetSuite login page")
+@when("I am in NetSuite login page")
 def see_sf_login_page():
     LOGIN_PAGE.open_page()
     common.wait_page_element_load(LOGIN_PAGE.driver, LOGIN_PAGE.login_button)
@@ -35,9 +37,3 @@ def perform_login():
 def see_home_page():
     check_additional_authentication()
     common.wait_element_to_be_clickable(LOGIN_PAGE.driver, LOGIN_PAGE.logo_img)
-
-@given("I am in NetSuite login page")
-@when("I am in NetSuite login page")
-def see_sf_login_page():
-    LOGIN_PAGE.open_page(LOGIN_PAGE.ns_url)
-    common.wait_page_element_load(LOGIN_PAGE.driver, LOGIN_PAGE.login_button)

--- a/step_definitions/sf_login_steps.py
+++ b/step_definitions/sf_login_steps.py
@@ -1,9 +1,20 @@
 import common
 from page_objects.sf_login_page import SFLoginPage
 from pytest_bdd import given, when
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 
 LOGIN_PAGE = SFLoginPage()
 AGENT_CREDENTIALS = {}
+
+def check_additional_authentication():
+    try:
+        title = LOGIN_PAGE.get_ns_additional_auth_title().text
+        if title == "Additional Authentication Required":
+            LOGIN_PAGE.get_ns_additional_pass().send_keys("meet")
+            LOGIN_PAGE.get_ns_additional_submit_btn().click()
+        return
+    except (NoSuchElementException, TimeoutException):
+        return
 
 @given("I am in SF login page")
 @when("I am in SF login page")
@@ -12,6 +23,7 @@ def see_sf_login_page():
     common.wait_page_element_load(LOGIN_PAGE.driver, LOGIN_PAGE.login_button)
 
 @when("I perform SF login")
+@when("I perform NetSuite login")
 def perform_login():
     agent = AGENT_CREDENTIALS.get('agent_0')
     LOGIN_PAGE.get_user_input().send_keys(agent.get('user'))
@@ -19,5 +31,13 @@ def perform_login():
     LOGIN_PAGE.get_login_button().click()
 
 @when("I see the SF home page")
+@when("I see the NetSuite home page")
 def see_home_page():
+    check_additional_authentication()
     common.wait_element_to_be_clickable(LOGIN_PAGE.driver, LOGIN_PAGE.logo_img)
+
+@given("I am in NetSuite login page")
+@when("I am in NetSuite login page")
+def see_sf_login_page():
+    LOGIN_PAGE.open_page(LOGIN_PAGE.ns_url)
+    common.wait_page_element_load(LOGIN_PAGE.driver, LOGIN_PAGE.login_button)

--- a/test/features/adapters/netsuite_scenarios.feature
+++ b/test/features/adapters/netsuite_scenarios.feature
@@ -1,0 +1,95 @@
+Feature: NetSuite Adapter
+  As a user,
+  I want to check NetSuite interactions for call and chat
+  So I can confirm that NetSuite is working fine
+
+  Background:
+    Given I set the browser number 1
+    When I am in NetSuite login page
+    When I perform NetSuite login
+    When I see the NetSuite home page
+    When I launch the adapter
+    When I am in adapter login page
+    When I perform login in adapter
+
+    When I set the browser number 2
+    When I am in login page
+    When I perform login
+    When I see the home page
+    When I select adp from menu
+    When I check the new browser tab opened
+
+  @adt_basic_calls
+  Scenario Outline: Check NetSuite basic calls
+    When I set the browser number 1
+    When I select <station> for adapter station type
+    When I configure adapter station with <station_id> id
+    When I confirm the station selection
+    When I select all skill in adapter
+    When I confirm the skills selection
+
+    When I see the adapter agent home page
+    When I select make a call option
+    When I fill <inbound_number2> in call input number
+    When I select cert_out campaign in adapter
+    When I select dial number button
+    When I select adapter script button
+    When I check the call script window
+    When I close the current browser tab
+    When I switch to tab with Adapter title
+    When I select adapter worksheet button
+    When I check the call worksheet window
+    When I fill the adapter worksheet
+    When I switch to tab with Adapter title
+    When I select adapter worksheet button
+    When I check the call worksheet window
+    When I close the current browser tab
+    When I switch to tab with Adapter title
+    When I open adapter disposition options
+    When I select adapter No Disposition disposition
+    When I end adapter call interaction
+    When I check the call connector tab
+    When I close the current browser tab
+
+    When I switch to tab with Adapter title
+    When I change adapter agent state to ready for voice
+
+    When I set the browser number 2
+    When I select <station2> for station type
+    When I configure station with <station2_id> id
+    When I proceed to next step
+    When I select all skills
+    When I proceed to next step
+    When I see the agent home page
+    When I call <inbound_number1>
+
+    When I set the browser number 1
+    When I accept the inbound call in adapter
+    When I select adapter script button
+    When I check the call script window
+    When I close the current browser tab
+    When I switch to tab with Adapter title
+    When I select adapter worksheet button
+    When I check the call worksheet window
+    When I fill the adapter worksheet
+    When I switch to tab with Adapter title
+    When I select adapter worksheet button
+    When I check the call worksheet window
+    When I close the current browser tab
+    When I switch to tab with Adapter title
+    When I open adapter disposition options
+    When I select adapter No Disposition disposition
+    When I end adapter call interaction
+    When I check the call connector tab
+    When I close the current browser tab
+    When I switch to tab with Adapter title
+
+    When I set the browser number 2
+    When I set No Disposition disposition
+
+    When I perform logout in adapter
+    Then I perform logout  
+
+    Examples:
+    | station   | station_id      | station2  | station2_id     | inbound_number1 | inbound_number2 |
+    | Softphone | 660200000001164 | WebRTC    | 660200000001165 | +18882620935    | +18884343521    |

--- a/test/initialization/adt_plus_scenarios.py
+++ b/test/initialization/adt_plus_scenarios.py
@@ -1,8 +1,3 @@
-import pyautogui
-import common
-from selenium.webdriver import ActionChains
-from selenium.webdriver.common.by import By
-
 import driver
 from step_definitions import common_steps, script_steps, call_interaction_steps
 from step_definitions.adapters import adapter_login_steps, adapter_steps, adapter_worksheet_steps
@@ -20,96 +15,7 @@ def check_adt_basic_calls():
     # find the extension
     for _driver in driver.DRIVERS:
         driver_ = driver.DRIVERS.get(_driver).get('instance')
-        set_adapter_shortcut(driver_, adapter_login_steps.EXTENSION_NAME)
-        set_adapter_url(driver_, set_adapter_shortcut(driver_, adapter_login_steps.EXTENSION_NAME, True))
+        common_steps.set_adapter_shortcut(driver_, adapter_login_steps.EXTENSION_NAME)
+        common_steps.set_adapter_url(driver_, common_steps.set_adapter_shortcut(driver_, adapter_login_steps.EXTENSION_NAME, True), adapter_login_steps.ADAPTER_LOGIN_PAGE)
 
-    # open the adapter window
-    for _driver in driver.DRIVERS:
-        driver_ = driver.DRIVERS.get(_driver).get('instance')
-        driver_.switch_to.window(driver_.current_window_handle)
-        for attempt in range(10):
-            common.wait_element_to_be_clickable(driver_, "//body")
-            common.click_element(driver_, driver_.find_element(By.TAG_NAME, "body"))
-            pyautogui.hotkey(
-                adapter_login_steps.PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[1], 'i')
-            common.system_wait(2)
-            if len(driver_.window_handles) > 1:
-                common.switch_tabs(driver_=driver_, tab_id=driver_.window_handles[1])
-                if driver_.title != 'Adapter':
-                    common.wait_page_element_load(driver_, "//*[@id='username']", 60)
-                    break
-
-
-# ----- SETUP ----- #
-def set_adapter_shortcut(driver_, extension_text, return_id=False):
-    driver_.get("chrome://extensions")
-    extension_manager_element_shadow = driver_.find_element(By.XPATH, "//extensions-manager")
-    extension_items_list_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
-                                                                                            "#items-list")
-    extensions = extension_items_list_shadow.shadow_root.find_elements(By.CSS_SELECTOR, "extensions-item")
-    selected_extension = None
-    for extension in extensions:
-        extension_name = extension.shadow_root.find_element(By.CSS_SELECTOR, "#name").text.strip()
-        if extension_name == extension_text:
-            selected_extension = extension
-            break
-    if not selected_extension:
-        raise Exception(f"extension {extension_text} not found")
-
-    # open extension options
-    selected_extension.shadow_root.find_element(By.CSS_SELECTOR, "#detailsButton").click()
-    common.wait_page_to_be(driver_, "?id=")
-    if return_id:
-        return driver_.current_url.split("?id=")[1].strip()
-
-    left_panel_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR, "extensions-sidebar")
-    keyboard_shortcuts = left_panel_shadow.shadow_root.find_element(By.CSS_SELECTOR, "a#sectionsShortcuts")
-    keyboard_shortcuts.click()
-
-    keyboard_shortcuts_content_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
-                                                                                                  "extensions-keyboard-shortcuts")
-    extension_cards = keyboard_shortcuts_content_shadow.shadow_root.find_elements(By.CSS_SELECTOR, ".shortcut-card")
-    selected_extension_card = None
-    for extension_card in extension_cards:
-        if extension_text in extension_card.text:
-            selected_extension_card = extension_card
-            break
-    if not selected_extension_card:
-        raise Exception(f"card for {extension_text} extension not found")
-
-    action = ActionChains(driver_)
-    edit_shortcut_shadow = selected_extension_card.find_element(By.CSS_SELECTOR, "extensions-shortcut-input")
-    edit_shortcut_button = edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-icon-button#edit")
-    edit_shortcut_button.click()
-    edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-input").shadow_root.find_element(By.CSS_SELECTOR, "#input").click()
-    action.key_down(adapter_login_steps.PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
-        .send_keys('i')\
-        .key_up(adapter_login_steps.PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
-        .perform()
-
-
-def set_adapter_url(driver_, extension_id):
-    lab_config = f"configuration/lab/{common.get_config_file_section('config.yml', 'configuration').get('lab')}.yml"
-    adapter_url = common.get_config_file_section(lab_config, 'configuration').get('adapter_login_url')
-    if not adapter_url:
-        adapter_url = adapter_login_steps.ADAPTER_LOGIN_PAGE.url
-    adapter_login_steps.ADAPTER_LOGIN_PAGE.url = adapter_url
-    driver_.get(f"chrome-extension://{extension_id}/options.html")
-    common.system_wait(2)
-
-    # set extension url
-    input_url = driver_.find_element(By.XPATH, "//input[@id='url']")
-    input_url.clear()
-    input_url.click()
-    input_url.send_keys(adapter_url)
-    try:
-        assert input_url.get_attribute('value') == adapter_url
-    except AssertionError:
-        input_url.clear()
-        input_url.send_keys(adapter_url)
-        assert input_url.get_attribute('value') == adapter_url, "COULD NOT SET THE CORRECT URL"
-    driver_.find_element(By.XPATH, "//button[@id='save']").click()
-    common.wait_element_attribute_contains(driver_, "//mark[@id='status']", 'innerText', "Options Saved")
-    tab_info = {'title': driver_.title,
-                'browser_number': int(common.get_driver_by_instance(driver_))}
-    common.BROWSER_TABS[driver_.current_window_handle] = tab_info
+    adapter_login_steps.launch_adapter()

--- a/test/initialization/netsuite_scenarios.py
+++ b/test/initialization/netsuite_scenarios.py
@@ -22,6 +22,7 @@ def check_netsuite_basic_calls():
 
     try:
         sf_login_steps.AGENT_CREDENTIALS = get_config_file_section(lab_config, 'ns_credentials')
+        sf_login_steps.LOGIN_PAGE.url = sf_login_steps.LOGIN_PAGE.ns_url
     except KeyError as e:
         print(f'could not find "credentials" section in {driver.CONFIG_FILE}.\n{e}\nusing the default...')
         sf_login_steps.AGENT_CREDENTIALS = get_config_file_section('config.yml', 'credentials')

--- a/test/initialization/netsuite_scenarios.py
+++ b/test/initialization/netsuite_scenarios.py
@@ -1,0 +1,112 @@
+import pyautogui
+from common import *
+from selenium.webdriver import ActionChains
+from selenium.webdriver.common.by import By
+
+import driver
+from step_definitions import common_steps, script_steps, call_interaction_steps, sf_login_steps
+from step_definitions.adapters import adapter_login_steps, adapter_steps, adapter_worksheet_steps
+from test.initialization import base_setup
+
+
+def check_netsuite_basic_calls():
+    base_setup.set_base_pages(instances=2)
+    common_steps.STARTED_PAGES.append(adapter_login_steps.ADAPTER_LOGIN_PAGE)
+    common_steps.STARTED_PAGES.append(script_steps.SCRIPT_PAGE)
+    common_steps.STARTED_PAGES.append(adapter_steps.ADAPTER_PAGE)
+    common_steps.STARTED_PAGES.append(adapter_worksheet_steps.ADAPTER_WORKSHEET_PAGE)
+    common_steps.STARTED_PAGES.append(call_interaction_steps.CALL_INTERACTION_PAGE)
+    common_steps.STARTED_PAGES.append(sf_login_steps.LOGIN_PAGE)
+
+    lab_config = f"configuration/lab/{get_config_file_section('config.yml', 'configuration').get('lab')}.yml"
+    connector_url_ = get_config_file_section(lab_config, 'configuration').get('connector_url')
+    if connector_url_:
+        call_interaction_steps.CALL_INTERACTION_PAGE.connector_url = connector_url_
+
+    try:
+        sf_login_steps.AGENT_CREDENTIALS = get_config_file_section(lab_config, 'ns_credentials')
+    except KeyError as e:
+        print(f'could not find "credentials" section in {driver.CONFIG_FILE}.\n{e}\nusing the default...')
+        sf_login_steps.AGENT_CREDENTIALS = get_config_file_section('config.yml', 'credentials')
+
+    # find the extension
+    for _driver in driver.DRIVERS:
+        driver_ = driver.DRIVERS.get(_driver).get('instance')
+        set_adapter_shortcut(driver_, "Five9Lab Plus Adapter for NetSuite")
+        set_adapter_url(driver_, set_adapter_shortcut(driver_, "Five9Lab Plus Adapter for NetSuite", True))
+        break
+
+# ----- SETUP ----- #
+def set_adapter_shortcut(driver_, extension_text, return_id=False):
+    driver_.get("chrome://extensions")
+    extension_manager_element_shadow = driver_.find_element(By.XPATH, "//extensions-manager")
+    extension_items_list_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
+                                                                                            "#items-list")
+    extensions = extension_items_list_shadow.shadow_root.find_elements(By.CSS_SELECTOR, "extensions-item")
+    selected_extension = None
+    for extension in extensions:
+        extension_name = extension.shadow_root.find_element(By.CSS_SELECTOR, "#name").text.strip()
+        if extension_name == extension_text:
+            selected_extension = extension
+            break
+    if not selected_extension:
+        raise Exception(f"extension {extension_text} not found")
+
+    # open extension options
+    selected_extension.shadow_root.find_element(By.CSS_SELECTOR, "#detailsButton").click()
+    wait_page_to_be(driver_, "?id=")
+    if return_id:
+        return driver_.current_url.split("?id=")[1].strip()
+
+    left_panel_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR, "extensions-sidebar")
+    keyboard_shortcuts = left_panel_shadow.shadow_root.find_element(By.CSS_SELECTOR, "a#sectionsShortcuts")
+    keyboard_shortcuts.click()
+
+    keyboard_shortcuts_content_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
+                                                                                                  "extensions-keyboard-shortcuts")
+    extension_cards = keyboard_shortcuts_content_shadow.shadow_root.find_elements(By.CSS_SELECTOR, ".shortcut-card")
+    selected_extension_card = None
+    for extension_card in extension_cards:
+        if extension_text in extension_card.text:
+            selected_extension_card = extension_card
+            break
+    if not selected_extension_card:
+        raise Exception(f"card for {extension_text} extension not found")
+
+    action = ActionChains(driver_)
+    edit_shortcut_shadow = selected_extension_card.find_element(By.CSS_SELECTOR, "extensions-shortcut-input")
+    edit_shortcut_button = edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-icon-button#edit")
+    edit_shortcut_button.click()
+    edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-input").shadow_root.find_element(By.CSS_SELECTOR, "#input").click()
+    action.key_down(adapter_login_steps.PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
+        .send_keys('i')\
+        .key_up(adapter_login_steps.PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
+        .perform()
+
+
+def set_adapter_url(driver_, extension_id):
+    lab_config = f"configuration/lab/{get_config_file_section('config.yml', 'configuration').get('lab')}.yml"
+    adapter_url = get_config_file_section(lab_config, 'configuration').get('adapter_ns_login_url')
+    if not adapter_url:
+        adapter_url = adapter_login_steps.ADAPTER_LOGIN_PAGE.url
+    adapter_login_steps.ADAPTER_LOGIN_PAGE.url = adapter_url
+    driver_.get(f"chrome-extension://{extension_id}/options.html")
+    system_wait(2)
+
+    # set extension url
+    driver_.find_element(By.XPATH, "//select[@id='domain-select']/option[@value='Custom']").click()
+    input_url = driver_.find_element(By.XPATH, "//input[@id='custom-host']")
+    input_url.clear()
+    input_url.click()
+    input_url.send_keys(adapter_url)
+    try:
+        assert input_url.get_attribute('value') == adapter_url
+    except AssertionError:
+        input_url.clear()
+        input_url.send_keys(adapter_url)
+        assert input_url.get_attribute('value') == adapter_url, "COULD NOT SET THE CORRECT URL"
+    driver_.find_element(By.XPATH, "//button[@id='save']").click()
+    wait_element_attribute_contains(driver_, "//mark[@id='status']", 'innerText', "Options Saved")
+    tab_info = {'title': driver_.title,
+                'browser_number': int(get_driver_by_instance(driver_))}
+    BROWSER_TABS[driver_.current_window_handle] = tab_info

--- a/test/initialization/netsuite_scenarios.py
+++ b/test/initialization/netsuite_scenarios.py
@@ -1,7 +1,4 @@
-import pyautogui
 from common import *
-from selenium.webdriver import ActionChains
-from selenium.webdriver.common.by import By
 
 import driver
 from step_definitions import common_steps, script_steps, call_interaction_steps, sf_login_steps
@@ -32,81 +29,6 @@ def check_netsuite_basic_calls():
     # find the extension
     for _driver in driver.DRIVERS:
         driver_ = driver.DRIVERS.get(_driver).get('instance')
-        set_adapter_shortcut(driver_, "Five9Lab Plus Adapter for NetSuite")
-        set_adapter_url(driver_, set_adapter_shortcut(driver_, "Five9Lab Plus Adapter for NetSuite", True))
+        common_steps.set_adapter_shortcut(driver_, adapter_login_steps.NS_EXTENSION_NAME)
+        common_steps.set_adapter_url(driver_, common_steps.set_adapter_shortcut(driver_, adapter_login_steps.NS_EXTENSION_NAME, True), adapter_login_steps.ADAPTER_LOGIN_PAGE, 'adapter_ns_login_url')
         break
-
-# ----- SETUP ----- #
-def set_adapter_shortcut(driver_, extension_text, return_id=False):
-    driver_.get("chrome://extensions")
-    extension_manager_element_shadow = driver_.find_element(By.XPATH, "//extensions-manager")
-    extension_items_list_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
-                                                                                            "#items-list")
-    extensions = extension_items_list_shadow.shadow_root.find_elements(By.CSS_SELECTOR, "extensions-item")
-    selected_extension = None
-    for extension in extensions:
-        extension_name = extension.shadow_root.find_element(By.CSS_SELECTOR, "#name").text.strip()
-        if extension_name == extension_text:
-            selected_extension = extension
-            break
-    if not selected_extension:
-        raise Exception(f"extension {extension_text} not found")
-
-    # open extension options
-    selected_extension.shadow_root.find_element(By.CSS_SELECTOR, "#detailsButton").click()
-    wait_page_to_be(driver_, "?id=")
-    if return_id:
-        return driver_.current_url.split("?id=")[1].strip()
-
-    left_panel_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR, "extensions-sidebar")
-    keyboard_shortcuts = left_panel_shadow.shadow_root.find_element(By.CSS_SELECTOR, "a#sectionsShortcuts")
-    keyboard_shortcuts.click()
-
-    keyboard_shortcuts_content_shadow = extension_manager_element_shadow.shadow_root.find_element(By.CSS_SELECTOR,
-                                                                                                  "extensions-keyboard-shortcuts")
-    extension_cards = keyboard_shortcuts_content_shadow.shadow_root.find_elements(By.CSS_SELECTOR, ".shortcut-card")
-    selected_extension_card = None
-    for extension_card in extension_cards:
-        if extension_text in extension_card.text:
-            selected_extension_card = extension_card
-            break
-    if not selected_extension_card:
-        raise Exception(f"card for {extension_text} extension not found")
-
-    action = ActionChains(driver_)
-    edit_shortcut_shadow = selected_extension_card.find_element(By.CSS_SELECTOR, "extensions-shortcut-input")
-    edit_shortcut_button = edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-icon-button#edit")
-    edit_shortcut_button.click()
-    edit_shortcut_shadow.shadow_root.find_element(By.CSS_SELECTOR, "cr-input").shadow_root.find_element(By.CSS_SELECTOR, "#input").click()
-    action.key_down(adapter_login_steps.PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
-        .send_keys('i')\
-        .key_up(adapter_login_steps.PLATFORM_HOTKEYS.get(driver_.caps.get('platformName'))[0])\
-        .perform()
-
-
-def set_adapter_url(driver_, extension_id):
-    lab_config = f"configuration/lab/{get_config_file_section('config.yml', 'configuration').get('lab')}.yml"
-    adapter_url = get_config_file_section(lab_config, 'configuration').get('adapter_ns_login_url')
-    if not adapter_url:
-        adapter_url = adapter_login_steps.ADAPTER_LOGIN_PAGE.url
-    adapter_login_steps.ADAPTER_LOGIN_PAGE.url = adapter_url
-    driver_.get(f"chrome-extension://{extension_id}/options.html")
-    system_wait(2)
-
-    # set extension url
-    driver_.find_element(By.XPATH, "//select[@id='domain-select']/option[@value='Custom']").click()
-    input_url = driver_.find_element(By.XPATH, "//input[@id='custom-host']")
-    input_url.clear()
-    input_url.click()
-    input_url.send_keys(adapter_url)
-    try:
-        assert input_url.get_attribute('value') == adapter_url
-    except AssertionError:
-        input_url.clear()
-        input_url.send_keys(adapter_url)
-        assert input_url.get_attribute('value') == adapter_url, "COULD NOT SET THE CORRECT URL"
-    driver_.find_element(By.XPATH, "//button[@id='save']").click()
-    wait_element_attribute_contains(driver_, "//mark[@id='status']", 'innerText', "Options Saved")
-    tab_info = {'title': driver_.title,
-                'browser_number': int(get_driver_by_instance(driver_))}
-    BROWSER_TABS[driver_.current_window_handle] = tab_info

--- a/test/python/test_check_netsuite_scenarios.py
+++ b/test/python/test_check_netsuite_scenarios.py
@@ -1,0 +1,6 @@
+from pytest_bdd import scenario
+
+
+@scenario('../features/adapters/netsuite_scenarios.feature', 'Check NetSuite basic calls')
+def test_check_netsuite_basic_calls():
+    pass


### PR DESCRIPTION
Removed duplicated code on common.py (caused by merge conflict)
Updated local.yml to take into account the netsuite.crx file and commented the third_party_cookie_phaseout which was causing issues on SF adapter Updated qaXX.yml with the new needed fields (for Lab01 need to verify urls for adapters) Added new identifiers to sf_login_page.py for NetSuite test Added new identifiers to adapter_login_page.py for NetSuite test Added new steps to sf_login_steps.py for NetSuite test Added new step to adapter_login_steps.py to launch the adapter through a gherkin step instead of automatically on test initialization Created netsuite_scenarios.feature file
Created netsuite_scenarios.py file which is launching 1 browser window with adapter configured and 1 normal window Created test_check_netsuite_scenarios.py file